### PR TITLE
Add usb tty monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore any build directories anywhere in the repo
+# Matches `build/` at repo root and any nested `build/` directories
+build/
+**/build/
+**/build/**

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@
 build/
 **/build/
 **/build/**
+
+# CTest / CMake test temporary files and logs
+# Ignore test run temporary directories and common log files created by CTest
+build/Testing/
+**/Testing/
+Testing/Temporary/
+**/Testing/Temporary/
+LastTest.log
+CTestCostData.txt
+
+# Ignore core test artifacts that may be created by other test tools
+*.log

--- a/linux-mctp/libsermctp/include/sermctp/MctpBridge.hpp
+++ b/linux-mctp/libsermctp/include/sermctp/MctpBridge.hpp
@@ -1,6 +1,26 @@
-// Thin namespaced wrapper for the existing global `MctpBridge` class.
-// This wrapper forwards calls to the implementation in the global namespace
-// so users can migrate to `iotorch::sermctp::MctpBridge` gradually.
+/**
+ * @file MctpBridge.hpp (implementation copy, moved to ser mctp/detail)
+ *
+ * This implementation provides the internal `MctpBridge` used by the
+ * namespaced wrapper. It manages opening a serial endpoint, configuring the
+ * TTY, attaching it to the framer, and running the dispatch loop that
+ * forwards between the MCTP endpoint and the serial link.
+ *
+ * `open()` supports an optional `use_id_path_tag` boolean
+ * parameter (default `false`). If set to `true`, the first string parameter
+ * is interpreted as a `ID_PATH_TAG` udev identifier and the bridge will
+ * instantiate a `ManagedUsbTty` internally. The bridge will then use the
+ * duplicated PTY slave fd returned by the helper as the serial fd instead of
+ * opening a physical device path directly.
+ *
+ * Note on ID_PATH_TAG
+ * -------------------
+ * The udev property `ID_PATH_TAG` identifies the physical path of a USB
+ * device (the bus topology) and is used by this implementation to match a
+ * stable identifier for the target serial device. To query `ID_PATH_TAG` on
+ * the command line for a device node, run:
+ *    udevadm info -q property -n /dev/ttyUSB0 | grep -E '^(ID_PATH_TAG)='
+ */
 #pragma once
 #include <memory>
 #include <string>
@@ -16,8 +36,8 @@ public:
     ~MctpBridge() = default;
 
     bool open(const std::string& tty_path, BaudRate baud, bool hw_flow_control,
-              uint8_t local_eid, std::vector<uint8_t> peer_eids) {
-        return impl_->open(tty_path, baud, hw_flow_control, local_eid, std::move(peer_eids));
+              uint8_t local_eid, std::vector<uint8_t> peer_eids, bool use_id_path_tag = false) {
+        return impl_->open(tty_path, baud, hw_flow_control, local_eid, std::move(peer_eids), use_id_path_tag);
     }
 
     std::string getMctpIfName() const { return impl_->getMctpIfName(); }

--- a/linux-mctp/libsermctp/include/sermctp/detail/ManagedUsbTty.hpp
+++ b/linux-mctp/libsermctp/include/sermctp/detail/ManagedUsbTty.hpp
@@ -1,0 +1,96 @@
+/**
+ * @file ManagedUsbTty.hpp
+ * @brief Internal header for ManagedUsbTty helper.
+ *
+ * Internal header (not installed): helper to manage a persistent PTY and
+ * forward data to/from a physical USB serial device discovered via udev.
+ *
+ * The `ManagedUsbTty` class provides a non-throwing open/close API. Calling
+ * `open()` creates a PTY and returns a duplicated slave fd which the caller
+ * owns and must close. The implementation runs a background thread which
+ * monitors udev for a physical tty with the requested `ID_PATH_TAG` and
+ * forwards data bidirectionally between the PTY master and the physical
+ * device when it is present. Calls return negative `ManagedUsbTtyErr` codes
+ * on failure.
+ *
+ * @author Doug Sandy (doug@picmg.org)
+ * @license MIT No Attribution (MIT-0)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+ */
+#pragma once
+
+#include <string>
+#include <thread>
+#include <atomic>
+#include <libudev.h>
+
+namespace sermctp::detail {
+
+enum ManagedUsbTtyErr {
+    MUSB_OK = 0,
+    MUSB_ERR_PTY = -1,
+    MUSB_ERR_PTY_DUP = -2,
+    MUSB_ERR_THREAD = -3,
+    MUSB_ERR_UDEV = -4,
+    MUSB_ERR_INVALID_ARG = -5,
+    MUSB_ERR_OPEN_TTY = -6,
+};
+
+/**
+ * @brief Internal helper that exposes an open/close API for a managed PTY.
+ *
+ * The class creates a PTY slave returned to the caller and runs a background
+ * thread that monitors udev and forwards data between the PTY master and a
+ * matching physical USB tty when it appears.
+ */
+class ManagedUsbTty {
+public:
+    ManagedUsbTty();
+    ~ManagedUsbTty();
+
+    // Create the persistent PTY and start the monitor/forwarder thread.
+    // Returns: duplicated slave fd >= 0 on success, negative ManagedUsbTtyErr on failure.
+    int open(const std::string &serial_id, int baudrate, bool rts_cts) noexcept;
+
+    // Close the forwarder and release resources. Returns 0 on success or negative error code.
+    int close() noexcept;
+
+    // True if forwarder thread is running and PTY master present
+    bool isOpen() const noexcept;
+
+    // Non-copyable
+    ManagedUsbTty(const ManagedUsbTty &) = delete;
+    ManagedUsbTty &operator=(const ManagedUsbTty &) = delete;
+
+private:
+    void threadMain();
+    int configureSerial(int fd, int baudrate, bool rts_cts) noexcept;
+    bool matchesSerialId(struct ::udev_device *probe) const noexcept;
+
+    std::thread worker;
+    std::atomic<bool> running;
+
+    // PTY master fd used for forwarding
+    int pty_master_fd;
+
+    // current physical TTY fd (-1 if not present)
+    int phys_fd;
+
+    // store requested params
+    std::string serialId;
+    int baud;
+    bool hwfc;
+
+    // udev objects are created in thread; keep pointers here for cleanup
+    struct ::udev *udev_ctx;
+    struct ::udev_monitor *udev_mon;
+    int udev_fd;
+};
+
+} // namespace sermctp::detail

--- a/linux-mctp/libsermctp/include/sermctp/detail/MctpBridge_impl.hpp
+++ b/linux-mctp/libsermctp/include/sermctp/detail/MctpBridge_impl.hpp
@@ -1,5 +1,25 @@
 /**
  * @file MctpBridge.hpp (implementation copy, moved to ser mctp/detail)
+ *
+ * This implementation provides the internal `MctpBridge` used by the
+ * namespaced wrapper. It manages opening a serial endpoint, configuring the
+ * TTY, attaching it to the framer, and running the dispatch loop that
+ * forwards between the MCTP endpoint and the serial link.
+ *
+ * `open()` supports an optional `use_id_path_tag` boolean
+ * parameter (default `false`). If set to `true`, the first string parameter
+ * is interpreted as a `ID_PATH_TAG` udev identifier and the bridge will
+ * instantiate a `ManagedUsbTty` internally. The bridge will then use the
+ * duplicated PTY slave fd returned by the helper as the serial fd instead of
+ * opening a physical device path directly.
+ *
+ * Note on ID_PATH_TAG
+ * -------------------
+ * The udev property `ID_PATH_TAG` identifies the physical path of a USB
+ * device (the bus topology) and is used by this implementation to match a
+ * stable identifier for the target serial device. To query `ID_PATH_TAG` on
+ * the command line for a device node, run:
+ *    udevadm info -q property -n /dev/ttyUSB0 | grep -E '^(ID_PATH_TAG)='
  */
 #pragma once
 #include <string>
@@ -9,6 +29,7 @@
 #include "sermctp/detail/MctpFramer_impl.hpp"
 #include <memory>
 #include "sermctp/export.h"
+#include "sermctp/detail/ManagedUsbTty.hpp"
 // forward-declare BcastMessenger so it doesn't leak into public headers
 class BcastMessenger;
 extern "C" {
@@ -47,7 +68,8 @@ public:
     MctpBridge();
     ~MctpBridge();
     bool open(const std::string& tty_path, BaudRate baud, bool hw_flow_control,
-              uint8_t local_eid, std::vector<uint8_t> peer_eids);
+              uint8_t local_eid, std::vector<uint8_t> peer_eids,
+              bool use_id_path_tag = false);
     std::string getMctpIfName() const;
     std::string getBroadcastName() const;
     void close();
@@ -63,6 +85,7 @@ private:
     std::string tty_name;
     std::atomic<bool> running;
     std::thread dispatch_thread;
+    std::unique_ptr<sermctp::detail::ManagedUsbTty> managedUsb;
     bool setup_bcast(std::string name);
     void run();
 };

--- a/linux-mctp/libsermctp/src/CMakeLists.txt
+++ b/linux-mctp/libsermctp/src/CMakeLists.txt
@@ -27,6 +27,12 @@ include_directories(${LIBNL3_INCLUDE_DIRS})
 link_directories(${LIBNL3_LIBRARY_DIRS})
 add_definitions(${LIBNL3_CFLAGS_OTHER})
 
+# libudev is required when ManagedUsbTty is used; link it unconditionally
+pkg_check_modules(LIBUDEV REQUIRED libudev)
+include_directories(${LIBUDEV_INCLUDE_DIRS})
+link_directories(${LIBUDEV_LIBRARY_DIRS})
+add_definitions(${LIBUDEV_CFLAGS_OTHER})
+
 # Collect sources (explicit listing is preferred long-term)
 file(GLOB_RECURSE MCTP_SRCS CONFIGURE_DEPENDS "*.cpp" "*.c")
 
@@ -139,7 +145,7 @@ if(BUILD_STATIC_LIBS)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   )
 endif()
-target_link_libraries(sermctp PUBLIC ${LIBNL3_LIBRARIES})
+target_link_libraries(sermctp PUBLIC ${LIBNL3_LIBRARIES} ${LIBUDEV_LIBRARIES})
 
 if(BUILD_TESTS)
   # When building tests in-tree, expose the tests/ headers to the build so

--- a/linux-mctp/libsermctp/src/ManagedUsbTty.cpp
+++ b/linux-mctp/libsermctp/src/ManagedUsbTty.cpp
@@ -1,0 +1,431 @@
+/**
+ * @file ManagedUsbTty.cpp
+ * @brief Managed PTY that forwards between a persistent PTY and a USB serial tty.
+ *
+ * This internal implementation creates a PTY whose slave is returned to callers
+ * while a background thread monitors udev for a physical USB tty matching a
+ * requested persistent identifier (ID_PATH_TAG). When a matching device is
+ * added the implementation opens and configures the physical tty and forwards
+ * data bidirectionally between the PTY master and the physical device using
+ * epoll for efficient multiplexing.
+ *
+ * The API is non-throwing and returns negative error codes defined in
+ * `ManagedUsbTty.hpp`.
+ *
+ * Note on ID_PATH_TAG
+ * -------------------
+ * The udev property `ID_PATH_TAG` identifies the physical path of a USB
+ * device (the bus topology) and is used by this implementation to match a
+ * stable identifier for the target serial device. To query `ID_PATH_TAG` on
+ * the command line for a device node, run:
+ *    udevadm info -q property -n /dev/ttyUSB0 | grep -E '^(ID_PATH_TAG)='
+ *
+ * @author Doug Sandy (doug@picmg.org)
+ * @license MIT No Attribution (MIT-0)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+ */
+
+#include "sermctp/detail/ManagedUsbTty.hpp"
+#include <unistd.h>
+#include <pty.h>
+#include <fcntl.h>
+#include <cstring>
+#include <cerrno>
+#include <iostream>
+#include <sys/epoll.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <libudev.h>
+
+using namespace sermctp::detail;
+
+ManagedUsbTty::ManagedUsbTty()
+    : running(false), pty_master_fd(-1), phys_fd(-1), baud(0), hwfc(false), udev_ctx(nullptr), udev_mon(nullptr), udev_fd(-1) {}
+
+/**
+ * @brief Destructor — stop forwarding and release resources.
+ *
+ * Calls `close()` to stop the background thread and close internal file
+ * descriptors. The caller-owned slave fd returned by `open()` is not closed
+ * by this destructor; the caller remains responsible for it.
+ */
+ManagedUsbTty::~ManagedUsbTty() {
+    close();
+}
+
+/**
+ * @brief Set a file descriptor to non-blocking mode.
+ *
+ * Returns 0 on success or -1 on failure and does not modify errno on
+ * success. This helper is intentionally minimal and internal-only.
+ *
+ * @param fd File descriptor to set non-blocking.
+ * @return 0 on success, -1 on failure.
+ */
+static int set_nonblocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return -1;
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) return -1;
+    return 0;
+}
+
+/**
+ * @brief Add a file descriptor to an epoll instance for read/error events.
+ *
+ * Logs epoll_ctl failures to stderr for debugging; this helper keeps the
+ * epoll interaction out of the main thread loop to keep that code clearer.
+ *
+ * @param epfd Epoll instance fd returned from epoll_create1().
+ * @param fd   File descriptor to register with epoll.
+ * @return void
+ */
+static void add_epoll_fd(int epfd, int fd) {
+    if (epfd < 0 || fd < 0) return;
+    struct epoll_event ev{};
+    ev.events = EPOLLIN | EPOLLHUP | EPOLLERR;
+    ev.data.fd = fd;
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) < 0) {
+        std::perror("add_epoll_fd: epoll_ctl ADD");
+    }
+}
+
+/**
+ * @brief Apply termios settings to a serial device fd.
+ *
+ * Sets raw mode, disables software flow control (XON/XOFF), adjusts RTS/CTS
+ * hardware flow control according to `rts_cts`, and applies the requested
+ * baud rate. Returns MUSB_OK on success or a negative error code.
+ *
+ * @param fd The open file descriptor for the serial device.
+ * @param baudrate Baud rate as an integer (mapped via cfset* calls).
+ * @param rts_cts Enable hardware RTS/CTS flow control if true.
+ * @return MUSB_OK on success or a negative ManagedUsbTtyErr code on failure.
+ */
+int ManagedUsbTty::configureSerial(int fd, int baudrate, bool rts_cts) noexcept {
+    if (fd < 0) return MUSB_ERR_OPEN_TTY;
+    struct termios tty;
+    if (tcgetattr(fd, &tty) != 0) return MUSB_ERR_OPEN_TTY;
+
+    // Set baud
+    cfsetospeed(&tty, static_cast<speed_t>(baudrate));
+    cfsetispeed(&tty, static_cast<speed_t>(baudrate));
+
+    // Input flags - clear processing and disable software flow control
+    tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+    // Output flags - disable post-processing
+    tty.c_oflag &= ~OPOST;
+    // Control flags - set 8N1
+    tty.c_cflag &= ~(CSIZE | PARENB);
+    tty.c_cflag |= CS8;
+    // Local flags - disable echo and canonical
+    tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+
+    if (!rts_cts) {
+        tty.c_cflag &= ~CRTSCTS;
+    } else {
+        tty.c_cflag |= CRTSCTS;
+    }
+
+    if (tcsetattr(fd, TCSANOW, &tty) != 0) return MUSB_ERR_OPEN_TTY;
+
+    // set non-blocking for async IO
+    set_nonblocking(fd);
+    return MUSB_OK;
+}
+
+/**
+ * @brief Check whether a udev device matches the configured serial id.
+ *
+ * Compares the device's `ID_PATH_TAG` property against the stored
+ * `serialId` string.
+ *
+ * @param probe udev device to probe (may be a proxied probe device).
+ * @return true if the device matches the requested `serialId`, false otherwise.
+ */
+bool ManagedUsbTty::matchesSerialId(struct ::udev_device *probe) const noexcept {
+    if (!probe) return false;
+    const char *id_path_tag = udev_device_get_property_value(probe, "ID_PATH_TAG");
+    if (!id_path_tag) return false;
+    return serialId == std::string(id_path_tag);
+}
+
+/**
+ * @brief Create a PTY, start the monitor/forwarding thread, and return a slave fd.
+ *
+ * The returned value is a duplicated slave fd owned by the caller; the
+ * ManagedUsbTty instance will keep the master fd for forwarding. On error a
+ * negative ManagedUsbTtyErr code is returned.
+ *
+ * @param serial_id Persistent serial identifier to match (ID_PATH_TAG).
+ * @param baudrate Baud rate to configure the physical tty when attached.
+ * @param rts_cts Whether to enable RTS/CTS hardware flow control.
+ * @return Duplicated slave fd (>=0) on success, or negative ManagedUsbTtyErr on failure.
+ */
+int ManagedUsbTty::open(const std::string &serial_id, int baudrate, bool rts_cts) noexcept {
+    if (running.load()) return MUSB_ERR_THREAD;
+    if (serial_id.empty()) return MUSB_ERR_INVALID_ARG;
+
+    serialId = serial_id;
+    baud = baudrate;
+    hwfc = rts_cts;
+
+    // Create pty
+    int master_fd = -1;
+    int slave_fd = -1;
+    char slave_name[64]{};
+    if (openpty(&master_fd, &slave_fd, slave_name, nullptr, nullptr) < 0) {
+        return MUSB_ERR_PTY;
+    }
+
+    // Configure slave as raw, no echo
+    struct termios tios{};
+    if (tcgetattr(slave_fd, &tios) == 0) {
+        cfmakeraw(&tios);
+        tios.c_lflag &= ~(ECHO | ECHONL);
+        tcsetattr(slave_fd, TCSANOW, &tios);
+    }
+
+    // Duplicate the slave fd to return to caller. Caller owns this dup and must close it.
+    int slave_dup = dup(slave_fd);
+    if (slave_dup < 0) {
+        ::close(master_fd);
+        ::close(slave_fd);
+        return MUSB_ERR_PTY_DUP;
+    }
+
+    // Close the copy of the slave we created via openpty; caller has dup
+    ::close(slave_fd);
+
+    // Keep master fd for internal forwarding
+    pty_master_fd = master_fd;
+    set_nonblocking(pty_master_fd);
+
+    // Start worker thread
+    running.store(true);
+    try {
+        worker = std::thread(&ManagedUsbTty::threadMain, this);
+    } catch (...) {
+        running.store(false);
+        ::close(pty_master_fd);
+        pty_master_fd = -1;
+        ::close(slave_dup);
+        return MUSB_ERR_THREAD;
+    }
+
+    // Return slave dup to caller (ownership to caller)
+    return slave_dup;
+}
+
+/**
+ * @brief Stop forwarding and close all internal resources.
+ *
+ * This will stop the background thread and close the PTY master and any
+ * opened physical tty. The duplicated slave fd returned to the caller by
+ * `open()` remains the caller's responsibility to close.
+ *
+ * @return MUSB_OK on success or a negative ManagedUsbTtyErr on failure.
+ */
+int ManagedUsbTty::close() noexcept {
+    if (!running.load() && pty_master_fd < 0 && phys_fd < 0) return MUSB_OK;
+
+    running.store(false);
+    if (worker.joinable()) worker.join();
+
+    if (phys_fd >= 0) {
+        ::close(phys_fd);
+        phys_fd = -1;
+    }
+    if (pty_master_fd >= 0) {
+        ::close(pty_master_fd);
+        pty_master_fd = -1;
+    }
+
+    // udev cleanup (if any left)
+    if (udev_mon) {
+        udev_monitor_unref(udev_mon);
+        udev_mon = nullptr;
+    }
+    if (udev_ctx) {
+        udev_unref(udev_ctx);
+        udev_ctx = nullptr;
+    }
+    udev_fd = -1;
+
+    return MUSB_OK;
+}
+
+/**
+ * @brief Query whether the forwarder thread is running and PTY master is present.
+ *
+ * @return true if the forwarder thread is active and PTY master is open.
+ */
+bool ManagedUsbTty::isOpen() const noexcept {
+    return running.load();
+}
+
+// Forwarding & udev watcher main loop
+/**
+ * @brief Main worker: monitor udev, manage phys fd, and forward data.
+ *
+ * This background thread creates a udev monitor, registers the PTY master
+ * and the udev monitor fd with epoll, and then loops forwarding data
+ * bidirectionally between the PTY master and the physical tty when present.
+ *
+ * @note This function runs on a dedicated thread and does not return until
+ *       `close()` signals shutdown via `running`.
+ */
+void ManagedUsbTty::threadMain() {
+    // Create udev and monitor
+    udev_ctx = udev_new();
+    if (!udev_ctx) {
+        std::cerr << "ManagedUsbTty: failed to create udev context\n";
+        // continue without udev - reconnection won't happen
+    } else {
+        udev_mon = udev_monitor_new_from_netlink(udev_ctx, "udev");
+        if (!udev_mon) {
+            std::cerr << "ManagedUsbTty: failed to create udev monitor\n";
+            udev_unref(udev_ctx);
+            udev_ctx = nullptr;
+        } else {
+            udev_monitor_enable_receiving(udev_mon);
+            udev_fd = udev_monitor_get_fd(udev_mon);
+            set_nonblocking(udev_fd);
+        }
+    }
+
+    const int MAX_EVENTS = 8;
+    int epfd = epoll_create1(0);
+    if (epfd < 0) {
+        std::perror("epoll_create1");
+        return;
+    }
+
+    // Register pty master and udev fd (if present)
+    add_epoll_fd(epfd, pty_master_fd);
+    if (udev_fd >= 0) add_epoll_fd(epfd, udev_fd);
+
+    while (running.load()) {
+        struct epoll_event events[MAX_EVENTS];
+        int timeout_ms = 500; // half-second to allow loop wakeups
+        int n = epoll_wait(epfd, events, MAX_EVENTS, timeout_ms);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            std::perror("epoll_wait");
+            break;
+        }
+
+        for (int i = 0; i < n; ++i) {
+            int fd = events[i].data.fd;
+            uint32_t ev = events[i].events;
+
+            if (udev_fd >= 0 && fd == udev_fd) {
+                // handle udev events
+                struct udev_device *dev = udev_monitor_receive_device(udev_mon);
+                if (!dev) continue;
+                const char *action = udev_device_get_action(dev);
+                const char *subsystem = udev_device_get_subsystem(dev);
+                if (!action || !subsystem) { udev_device_unref(dev); continue; }
+                if (std::strcmp(subsystem, "tty") != 0) { udev_device_unref(dev); continue; }
+
+                const char *devnode = udev_device_get_devnode(dev);
+                const char *syspath = udev_device_get_syspath(dev);
+
+                struct udev_device *probe = nullptr;
+                if (syspath) probe = udev_device_new_from_syspath(udev_ctx, syspath);
+                struct udev_device *use = probe ? probe : dev;
+
+                bool matched = matchesSerialId(use);
+
+                if (std::strcmp(action, "remove") == 0) {
+                    if (matched && phys_fd >= 0) {
+                        // Remove from epoll before closing fd so the epoll set stays consistent
+                        if (epfd >= 0) epoll_ctl(epfd, EPOLL_CTL_DEL, phys_fd, nullptr);
+                        ::close(phys_fd);
+                        phys_fd = -1;
+                    }
+                } else if (std::strcmp(action, "add") == 0) {
+                    if (matched && devnode) {
+                        // open device
+                        int ofd = ::open(devnode, O_RDWR | O_NOCTTY);
+                        if (ofd >= 0) {
+                            if (configureSerial(ofd, baud, hwfc) == MUSB_OK) {
+                                phys_fd = ofd;
+                                set_nonblocking(phys_fd);
+                                add_epoll_fd(epfd, phys_fd);
+                            } else {
+                                ::close(ofd);
+                            }
+                        }
+                    }
+                }
+
+                if (probe) udev_device_unref(probe);
+                udev_device_unref(dev);
+                continue;
+            }
+
+            if (fd == pty_master_fd) {
+                // data from PTY -> physical tty (if present)
+                char buf[4096];
+                ssize_t r = ::read(pty_master_fd, buf, sizeof(buf));
+                if (r > 0 && phys_fd >= 0) {
+                    ssize_t written = 0;
+                    while (written < r) {
+                        ssize_t w = ::write(phys_fd, buf + written, r - written);
+                        if (w < 0) {
+                            if (errno == EAGAIN || errno == EINTR) continue;
+                            // error writing - drop and close phys
+                            if (epfd >= 0) epoll_ctl(epfd, EPOLL_CTL_DEL, phys_fd, nullptr);
+                            ::close(phys_fd);
+                            phys_fd = -1;
+                            break;
+                        }
+                        written += w;
+                    }
+                }
+                continue;
+            }
+
+            if (phys_fd >= 0 && fd == phys_fd) {
+                // data from physical tty -> PTY
+                char buf[4096];
+                ssize_t r = ::read(phys_fd, buf, sizeof(buf));
+                if (r > 0) {
+                    ssize_t written = 0;
+                    while (written < r) {
+                        ssize_t w = ::write(pty_master_fd, buf + written, r - written);
+                        if (w < 0) {
+                            if (errno == EAGAIN || errno == EINTR) continue;
+                            // error writing -> close phys
+                            ::close(phys_fd);
+                            phys_fd = -1;
+                            break;
+                        }
+                        written += w;
+                    }
+                    } else if (r == 0) {
+                    // EOF: close phys_fd
+                    if (epfd >= 0) epoll_ctl(epfd, EPOLL_CTL_DEL, phys_fd, nullptr);
+                    ::close(phys_fd);
+                    phys_fd = -1;
+                } else {
+                    if (errno != EAGAIN && errno != EINTR) {
+                        if (epfd >= 0) epoll_ctl(epfd, EPOLL_CTL_DEL, phys_fd, nullptr);
+                        ::close(phys_fd);
+                        phys_fd = -1;
+                    }
+                }
+                continue;
+            }
+        }
+    }
+
+    ::close(epfd);
+}

--- a/linux-mctp/libsermctp/src/MctpBridge.cpp
+++ b/linux-mctp/libsermctp/src/MctpBridge.cpp
@@ -6,6 +6,21 @@
  * by configuring a TTY device with the MCTP line discipline, monitoring the creation
  * and removal of associated mctpserial network interfaces, and managing terminal settings.
  *
+ * `open()` now accepts an optional `use_id_path_tag` flag. When
+ * `use_id_path_tag` is true the `tty_path` argument is treated as an
+ * `ID_PATH_TAG` udev identifier and the bridge will instantiate a
+ * `ManagedUsbTty` helper which monitors udev and binds to the physical USB
+ * tty matching the provided ID. In that mode the bridge uses the duplicated
+ * PTY slave fd returned by `ManagedUsbTty::open()` as the serial fd.
+ *
+ * Note on ID_PATH_TAG
+ * -------------------
+ * The udev property `ID_PATH_TAG` identifies the physical path of a USB
+ * device (the bus topology) and is used by this implementation to match a
+ * stable identifier for the target serial device. To query `ID_PATH_TAG` on
+ * the command line for a device node, run:
+ *    udevadm info -q property -n /dev/ttyUSB0 | grep -E '^(ID_PATH_TAG)='
+ *
  * @author Doug Sandy (doug@picmg.org)
  * @license MIT No Attribution (MIT-0)
  *
@@ -17,6 +32,7 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
  */
 #include "sermctp/detail/MctpBridge_impl.hpp"
+#include "sermctp/detail/ManagedUsbTty.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <chrono>
@@ -80,9 +96,10 @@ MctpBridge::~MctpBridge() {
  *                 this reflects the desired name for the inerface.  It must be unique across the system.
  * @param local_eid Local Endpoint ID for the MCTP interface.
  * @param peer_eids Vector of peer Endpoint IDs for the MCTP interface. 
+ * @param use_id_path_tag true to interpret tty_path as an ID_PATH_TAG for ManagedUsbTty usage.
  * @return true on success, otherwise failure.
  */
-bool MctpBridge::open(const std::string& tty_path, BaudRate baud, bool hw_flow_control, uint8_t local_eid, std::vector<uint8_t> peer_eids) {
+bool MctpBridge::open(const std::string& tty_path, BaudRate baud, bool hw_flow_control, uint8_t local_eid, std::vector<uint8_t> peer_eids, bool use_id_path_tag) {
     // close if already configured.  this also stops the routing thread
     close();
 
@@ -100,56 +117,94 @@ bool MctpBridge::open(const std::string& tty_path, BaudRate baud, bool hw_flow_c
         return false;
     }
 
-    // connect to the physical interface
-    // Open and configure the physical TTY here (MctpBridge owns TTY config).
-    int fd = ::open(tty_path.c_str(), O_RDWR | O_NOCTTY);
-    if (fd < 0) {
-        std::cout << "MctpBridge failed to open TTY device\n";
-        close();
-        return false;
-    }
-    
-    // Configure termios as requested by caller
-    struct termios tty;
-    if (tcgetattr(fd, &tty) != 0) {
-        ::close(fd);
-        close();
-        return false;
-    }
-    cfsetospeed(&tty, static_cast<speed_t>(baud));
-    cfsetispeed(&tty, static_cast<speed_t>(baud));
-    // Input flags - clear processing and disable software flow control
-    tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-    // Output flags - disable post-processing
-    tty.c_oflag &= ~OPOST;
-    // Control flags - set 8N1
-    tty.c_cflag &= ~(CSIZE | PARENB);
-    tty.c_cflag |= CS8;
-    // Local flags - disable echo and canonical
-    tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-    // Hardware flow control
-    if (!hw_flow_control) {
-        tty.c_cflag &= ~CRTSCTS;
+    int fd = -1;
+    int pipefd = -1;
+
+    if (!use_id_path_tag) {
+        // connect to the physical interface
+        // Open and configure the physical TTY here (MctpBridge owns TTY config).
+        fd = ::open(tty_path.c_str(), O_RDWR | O_NOCTTY);
+        if (fd < 0) {
+            std::cerr << "MctpBridge failed to open TTY device\n";
+            close();
+            return false;
+        }
+
+        // Configure termios as requested by caller
+        struct termios tty;
+        if (tcgetattr(fd, &tty) != 0) {
+            ::close(fd);
+            close();
+            return false;
+        }
+        cfsetospeed(&tty, static_cast<speed_t>(baud));
+        cfsetispeed(&tty, static_cast<speed_t>(baud));
+        // Input flags - clear processing and disable software flow control
+        tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+        // Output flags - disable post-processing
+        tty.c_oflag &= ~OPOST;
+        // Control flags - set 8N1
+        tty.c_cflag &= ~(CSIZE | PARENB);
+        tty.c_cflag |= CS8;
+        // Local flags - disable echo and canonical
+        tty.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+        // Hardware flow control
+        if (!hw_flow_control) {
+            tty.c_cflag &= ~CRTSCTS;
+        } else {
+            tty.c_cflag |= CRTSCTS;
+        }
+
+        if (tcsetattr(fd, TCSANOW, &tty) != 0) {
+            ::close(fd);
+            close();
+            return false;
+        }
+
+        // Attach the configured fd to our framer so it can start processing.
+        pipefd = mctpSerial.openFd(fd);
+        if (pipefd < 0) {
+            ::close(fd);
+            close();
+            return false;
+        }
+        // Keep the original TTY fd for cleanup, but select() on the framer wake pipe
+        tty_raw_fd = fd;
+        tty_fd = pipefd;
     } else {
-        tty.c_cflag |= CRTSCTS;
-    }
+        // Use ManagedUsbTty: the passed string is the ID_PATH_TAG
+        try {
+            managedUsb = std::make_unique<sermctp::detail::ManagedUsbTty>();
+        } catch (...) {
+            std::cerr << "MctpBridge: failed to allocate ManagedUsbTty\n";
+            close();
+            return false;
+        }
 
-    if (tcsetattr(fd, TCSANOW, &tty) != 0) {
-        ::close(fd);
-        close();
-        return false;
-    }
+        int slave_dup = managedUsb->open(tty_path, static_cast<int>(baud), hw_flow_control);
+        if (slave_dup < 0) {
+            std::cerr << "MctpBridge: ManagedUsbTty failed to open ID_PATH_TAG='" << tty_path << "'\n";
+            managedUsb.reset();
+            close();
+            return false;
+        }
 
-    // Attach the configured fd to our framer so it can start processing.
-    int pipefd = mctpSerial.openFd(fd);
-    if (pipefd < 0) {
-        ::close(fd);
-        close();
-        return false;
+        // Attach duplicated slave fd to framer
+        pipefd = mctpSerial.openFd(slave_dup);
+        if (pipefd < 0) {
+            std::cerr << "MctpBridge: mctpSerial.openFd failed for ManagedUsbTty slave fd\n";
+            // stop managedUsb and close the duplicate
+            managedUsb->close();
+            ::close(slave_dup);
+            managedUsb.reset();
+            close();
+            return false;
+        }
+
+        // The bridge owns the dupfd for cleanup
+        tty_raw_fd = slave_dup;
+        tty_fd = pipefd;
     }
-    // Keep the original TTY fd for cleanup, but select() on the framer wake pipe
-    tty_raw_fd = fd;
-    tty_fd = pipefd;
 
     int linux_fd_diag = linuxEndpoint.getIsRxReadyFd();
     int framer_serial_fd = mctpSerial.getSerialFd();
@@ -177,6 +232,12 @@ void MctpBridge::close() {
 
      
     // close the original TTY fd (framer close() will close the duplicated fd and pipes)
+    // If we used ManagedUsbTty, stop it first so it shuts down worker and master fd
+    if (managedUsb) {
+        managedUsb->close();
+        managedUsb.reset();
+    }
+
     if (tty_raw_fd>=0) {
         ::close(tty_raw_fd);
         tty_raw_fd = -1;

--- a/linux-mctp/libsermctp/src/MctpBridge.cpp
+++ b/linux-mctp/libsermctp/src/MctpBridge.cpp
@@ -103,24 +103,30 @@ bool MctpBridge::open(const std::string& tty_path, BaudRate baud, bool hw_flow_c
     // close if already configured.  this also stops the routing thread
     close();
 
-    this->ifname = linuxEndpoint.initialize(ifname,local_eid,peer_eids);
-    if (this->ifname.empty()) {
-        std::cout << "MctpBridge LinuxMctpEndpoint initialization failed\n";
-        close();
-        return false;
-    } 
-    
-    this->broadcastName = "/tmp/bcast_"+this->ifname+".sock";
-    if (!bcast->open(broadcastName)) {
-        std::cout << "MctpBridge broadcast setup failed\n";
-        close();
-        return false;
-    }
+    this->broadcastName.clear();
+
+    // We'll initialize the Linux MCTP endpoint below once we know whether
+    // we're using a direct TTY or an ID_PATH_TAG-backed ManagedUsbTty.
 
     int fd = -1;
     int pipefd = -1;
 
     if (!use_id_path_tag) {
+        // Initialize Linux endpoint using a fresh PTY master created by LinuxMctpSerial
+        try {
+            this->ifname = linuxEndpoint.initialize(ifname, local_eid, peer_eids);
+        } catch (...) {
+            std::cerr << "MctpBridge LinuxMctpEndpoint initialization failed\n";
+            close();
+            return false;
+        }
+
+        this->broadcastName = "/tmp/bcast_"+this->ifname+".sock";
+        if (!bcast->open(broadcastName)) {
+            std::cout << "MctpBridge broadcast setup failed\n";
+            close();
+            return false;
+        }
         // connect to the physical interface
         // Open and configure the physical TTY here (MctpBridge owns TTY config).
         fd = ::open(tty_path.c_str(), O_RDWR | O_NOCTTY);
@@ -184,6 +190,29 @@ bool MctpBridge::open(const std::string& tty_path, BaudRate baud, bool hw_flow_c
         int slave_dup = managedUsb->open(tty_path, static_cast<int>(baud), hw_flow_control);
         if (slave_dup < 0) {
             std::cerr << "MctpBridge: ManagedUsbTty failed to open ID_PATH_TAG='" << tty_path << "'\n";
+            managedUsb.reset();
+            close();
+            return false;
+        }
+        // Initialize Linux endpoint as a decoupled kernel-side interface
+        // (LinuxMctpSerial creates its own PTY and manages the kernel mctpserial
+        // device). Keep LinuxMctpSerial independent of ManagedUsbTty.
+        try {
+            this->ifname = linuxEndpoint.initialize(ifname, local_eid, peer_eids);
+        } catch (...) {
+            std::cerr << "MctpBridge LinuxMctpEndpoint initialization failed\n";
+            managedUsb->close();
+            ::close(slave_dup);
+            managedUsb.reset();
+            close();
+            return false;
+        }
+
+        this->broadcastName = "/tmp/bcast_"+this->ifname+".sock";
+        if (!bcast->open(broadcastName)) {
+            std::cout << "MctpBridge broadcast setup failed\n";
+            managedUsb->close();
+            ::close(slave_dup);
             managedUsb.reset();
             close();
             return false;

--- a/linux-mctp/mctp-bridge/README.md
+++ b/linux-mctp/mctp-bridge/README.md
@@ -22,6 +22,10 @@ The bridge sits in user space with three logical links:
 
 - Port 1 — Kernel MCTP: a kernel-visible `mctp-serial<N>` interface. Kernel-land AF_MCTP sockets send unicast packets here and the kernel routes packets to the correct interface based on destination EID.  Optionally this interface may be renamed by command line arguments when the mctp-bridge is instantialed.
 - Port 2 — Serial Transport: the physical serial device (e.g. `/dev/ttyUSB0`). The bridge encodes and decodes MCTP frames to/from this link.
+Special handling is important in the case of a ttyUSB device since these devices are not persistent in the device map, and ttyUSB device names are not tied to specific ports.  Instead of using device names, the MctpBridge provides an alternate way of binding to usb-serial devices that uses the udev ID_PATH_ID, which provides a one-to-one correspondance with a specific output port as long as the system configuration is not changed (e.g. adding additional ports through hubs).  This capability offers two distinct benefts:
+  - a mappable correspondance between MctpBridge and a specific pysical usb connector (useful for maintainance)
+  - ability to recover when a ttyUSB device is removed and reinserted.  Based on the ID_PATH_TAG, newly discovered devices can be unambiguously associated with the physical port they were inserted in regardless of the name they are assigned. 
+
 - Port 3 — Broadcast interface that user-space processes use to send and receive broadcast MCTP messages via the bridge.  The name of this interface always matches the name of the kernel-facing interface, but prepended by `bcast`
 
 These three pieces let user processes talk to remote MCTP endpoints (unicast) via the kernel stack and participate in broadcast exchanges via the bridge's UNIX datagram socket.
@@ -61,6 +65,40 @@ See the top of the example script for more detailed usage notes and command-line
 ```bash
 sudo ./mctp-bridge --tty /dev/ttyUSB0 --ifname testbridge --baud B115200 --local-eid 8 --remote_eid 9 
 ```
+
+### Using the Python example with an ID_PATH_TAG
+
+The bridge and the Python example support binding to a persistent USB port identifier instead of a transient device node. Use `--id-path-tag` to select a physical USB port by its `ID_PATH_TAG` (mutually exclusive with `--tty`). Example:
+
+```bash
+# run the python example and bind by ID_PATH_TAG
+sudo python3 mctp-bridge/examples/python_mctp_bridge_example.py \
+  --id-path-tag pci-0000_00_14_0-usb-0_6_1_0 \
+  --local_eid 8 --remote_eid 9
+```
+
+How to determine the `ID_PATH_TAG` for an installed device
+
+You can get the `ID_PATH_TAG` for a plugged-in USB serial device using `udevadm` or by inspecting the `by-path` symlinks. Replace `/dev/ttyUSB0` with the device node you have:
+
+```bash
+# show the device properties and grep the tag
+udevadm info -q property -n /dev/ttyUSB0 | grep '^ID_PATH_TAG='
+
+# or list by-path entries to see which device maps to which physical path
+ls -l /dev/serial/by-path
+
+# iterate all ttyUSB devices and print their ID_PATH_TAG (useful when multiple present)
+for d in /dev/ttyUSB*; do
+  echo "Device: $d"
+  udevadm info -q property -n "$d" | grep '^ID_PATH_TAG=' || true
+done
+```
+
+Notes:
+- `--id-path-tag` is mutually exclusive with `--tty`; pick one form of binding when starting the bridge or the Python helper script.
+- The `ID_PATH_TAG` string comes from udev and typically looks like `pci-0000_00_14_0-usb-0_6_1_0` on many systems.
+
 
 ## Developer view
 

--- a/linux-mctp/mctp-bridge/examples/python_mctp_bridge_example.py
+++ b/linux-mctp/mctp-bridge/examples/python_mctp_bridge_example.py
@@ -13,6 +13,7 @@ The script requires root privileges to create AF_MCTP sockets.
 
 Usage: run from repository root:
     python3 mctp-bridge/examples/python_mctp_bridge_example.py --tty /dev/pts/X --local-eid 8 --remote-eid 9
+    python3 mctp-bridge/examples/python_mctp_bridge_example.py --id-path-tag "pci-0000:00:14.0-usb-0:3:1.0" --local-eid 8 --remote-eid 9
 
 Author: Doug Sandy <doug@picmg.org>
 License: MIT No Attribution (MIT-0)
@@ -113,7 +114,9 @@ def pack_sockaddr_mctp(eid, typ=1, tag=0, network=0, family=AF_MCTP):
 # set up the main interactive loop and loop until ctrl-c typed
 def run():
     parser = argparse.ArgumentParser(description="AF_MCTP interactive example")
-    parser.add_argument("--tty", required=True, help="TTY path to pass to mctp-bridge (required)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--tty", help="TTY path to pass to mctp-bridge (e.g. /dev/ttyUSB0)")
+    group.add_argument("--id-path-tag", help="udev ID_PATH_TAG to monitor instead of a tty path")
     parser.add_argument("--local-eid", type=int, default=8, help="Local EID to bind/send from (default: 8)")
     parser.add_argument("--remote-eid", type=int, default=9, help="Remote EID to send datagrams to (default: 9)")
     args = parser.parse_args()
@@ -126,8 +129,13 @@ def run():
     # launch the bridge.
     bridge_exe = "mctp-bridge"
     proc = None
-    chosen_tty = args.tty
-    cmd = [bridge_exe, "--tty", chosen_tty, "--local-eid", str(args.local_eid), "--remote-eid", str(args.remote_eid)]
+    # Determine whether to launch bridge with a tty path or an ID_PATH_TAG
+    if args.id_path_tag:
+        chosen_device = args.id_path_tag
+        cmd = [bridge_exe, "--id-path-tag", chosen_device, "--local-eid", str(args.local_eid), "--remote-eid", str(args.remote_eid)]
+    else:
+        chosen_device = args.tty
+        cmd = [bridge_exe, "--tty", chosen_device, "--local-eid", str(args.local_eid), "--remote-eid", str(args.remote_eid)]
     print("Launching mctp-bridge...")
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)    

--- a/linux-mctp/mctp-bridge/examples/python_mctp_bridge_example.py
+++ b/linux-mctp/mctp-bridge/examples/python_mctp_bridge_example.py
@@ -126,8 +126,13 @@ def run():
         print("Re-executing under sudo for privileged operations...")
         os.execvp("sudo", ["sudo", sys.executable] + sys.argv)
 
-    # launch the bridge.
-    bridge_exe = "mctp-bridge"
+    # launch the bridge. Try to find `mctp-bridge` in PATH first, then
+    # fall back to the in-tree build path (useful when running from source).
+    import shutil
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.abspath(os.path.join(script_dir, '..', '..'))
+    build_candidate = os.path.join(repo_root, 'build', 'linux-mctp', 'mctp-bridge', 'src', 'mctp-bridge')
+    bridge_exe = shutil.which('mctp-bridge') or (build_candidate if os.path.isfile(build_candidate) and os.access(build_candidate, os.X_OK) else None)
     proc = None
     # Determine whether to launch bridge with a tty path or an ID_PATH_TAG
     if args.id_path_tag:
@@ -136,12 +141,24 @@ def run():
     else:
         chosen_device = args.tty
         cmd = [bridge_exe, "--tty", chosen_device, "--local-eid", str(args.local_eid), "--remote-eid", str(args.remote_eid)]
-    print("Launching mctp-bridge...")
+    if not bridge_exe:
+        print("mctp-bridge executable not found in PATH or build tree. Build it or add to PATH.", file=sys.stderr)
+        sys.exit(1)
+
+    cmd[0] = bridge_exe
+    print("Launching mctp-bridge... (executable=", bridge_exe, ")")
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)    
+        # Launch bridge but hide its stdout/stderr so example output remains clean.
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except Exception as e:
         print(f"Failed to launch mctp-bridge: {e}", file=sys.stderr)
-    time.sleep(5)  # brief pause to allow bridge to initialize
+        sys.exit(1)
+
+    # wait a short moment to let the bridge initialize and print startup info
+    time.sleep(0.2)
+    if proc.poll() is not None:
+        print("mctp-bridge exited early", file=sys.stderr)
+        sys.exit(1)
 
     # create AF_MCTP sockets using libc
     bridge_fd = libc.socket(AF_MCTP, socket.SOCK_DGRAM, 0)

--- a/linux-mctp/mctp-bridge/src/mctp-bridge.cpp
+++ b/linux-mctp/mctp-bridge/src/mctp-bridge.cpp
@@ -43,10 +43,11 @@ struct CmdOptions {
     std::string tty;
     std::optional<BaudRate> baud;   // std::nullopt if not provided
     bool hwflow = false;            // default false
-    std::optional<std::string> ifname;
+    std::optional<std::string> ifname;       // desired MCTP interface name
+    std::optional<std::string> id_path_tag;  // ID_PATH_TAG (mutually exclusive with ifname)
     std::optional<int> local_eid;
     std::optional<int> remote_eid;
-};  
+};
 
 /*
  * @brief Handle signals (e.g., SIGINT, SIGTERM) by setting the interrupted flag.
@@ -100,15 +101,18 @@ void printUsage(const char* progName) {
     std::cout << "  --baud <baud-string>    Baud rate string (e.g. B9600, B115200). If omitted, default B115200 is used\n";
     std::cout << "  --hwflow <TRUE|FALSE>   Hardware flow control. TRUE to enable RTS/CTS, FALSE (default) to disable.\n";
     std::cout << "  --ifname <name>         Name of MCTP interface for socket connections (e.g. mctp0). Default: use linux-assigned name.\n";
+    std::cout << "  --id-path-tag <tag>     Use the udev ID_PATH_TAG identifier instead of a physical tty path.\n";
     std::cout << "  --local-eid <n>         Local endpoint ID (1-254). If not specified, the bridge is transparent.\n";
     std::cout << "  --help                  Show this help message and exit.\n\n";
 
     std::cout << "Examples:\n";
     std::cout << "  " << progName << " --tty /dev/ttyUSB0 --remote-eid 8 --baud B115200 --hwflow TRUE --ifname mctp0\n";
-    std::cout << "  " << progName << " --tty /dev/ttyS1 --remote-eid 8\n\n";
+    std::cout << "  " << progName << " --id-path-tag 'pci-0000:00:14.0-usb-0:3:1.0' --remote-eid 8 --baud B115200 --hwflow TRUE\n\n";
 
     std::cout << "Notes:\n";
     std::cout << "  - The code is blocking and will run until iterrupted with SIGINT.\n";
+    std::cout << "  - To determine the ID_PATH_TAG for a device node (e.g. /dev/ttyUSB0) run:\n";
+    std::cout << "      udevadm info -q property -n /dev/ttyUSB0 | grep -E '^(ID_PATH_TAG)='\n";
     std::cout << std::flush;
 }
 
@@ -164,6 +168,7 @@ std::optional<CmdOptions> parseArgs(int argc, char** argv) {
         {"baud",    required_argument, nullptr, 'b'},
         {"hwflow",  required_argument, nullptr, 'f'},
         {"ifname",  required_argument, nullptr, 'i'},
+        {"id-path-tag", required_argument, nullptr, 'p'},
         {"local-eid", required_argument, nullptr, 'L'},
         {"remote-eid",  required_argument, nullptr, 'R'},
         {"help",    no_argument,       nullptr, 'h'},
@@ -176,7 +181,7 @@ std::optional<CmdOptions> parseArgs(int argc, char** argv) {
 
     int opt;
     int longIndex = 0;
-    while ((opt = getopt_long(argc, argv, "t:b:f:i:L:R:h", longOpts, &longIndex)) != -1) {
+    while ((opt = getopt_long(argc, argv, "t:b:f:i:p:L:R:h", longOpts, &longIndex)) != -1) {
         switch (opt) {
         case 't':
             opts.tty = optarg;
@@ -205,6 +210,9 @@ std::optional<CmdOptions> parseArgs(int argc, char** argv) {
         case 'i':
             opts.ifname = std::string(optarg);
             break;
+        case 'p':
+            opts.id_path_tag = std::string(optarg);
+            break;
         case 'L': {
             int v = atoi(optarg);
             if (v < 1 || v > 254) {
@@ -232,9 +240,16 @@ std::optional<CmdOptions> parseArgs(int argc, char** argv) {
         }
     }
 
-    // Validate required options
-    if (!seenTty) {
-        std::cerr << "Missing required option: --tty\n";
+    // Validate required options: require either a tty path or an id-path-tag
+    if (!seenTty && !opts.id_path_tag.has_value()) {
+        std::cerr << "Missing required option: --tty or --id-path-tag\n";
+        printUsage(argv[0]);
+        return std::nullopt;
+    }
+
+    // --ifname and --id-path-tag are mutually exclusive
+    if (opts.ifname && opts.id_path_tag) {
+        std::cerr << "Options --ifname and --id-path-tag are mutually exclusive\n";
         printUsage(argv[0]);
         return std::nullopt;
     }
@@ -271,14 +286,32 @@ int main(int argc, char *argv[]) {
     BaudRate baud = BaudRate::BR_115200;
     if (opts.baud) baud = *opts.baud;
 
-    if (!mctpbridge.open(opts.tty.c_str(), baud, opts.hwflow, 
-                opts.local_eid ? static_cast<uint8_t>(*opts.local_eid) : 0,{static_cast<uint8_t>(*opts.remote_eid)})) {
-        std::cerr << "Failed to open serial bridge on " << opts.tty << "\n";
+    // Determine whether we are using an ID_PATH_TAG or a direct TTY path
+    std::string device_spec;
+    bool use_id_path_tag = false;
+    if (opts.id_path_tag) {
+        device_spec = *opts.id_path_tag;
+        use_id_path_tag = true;
+    } else {
+        device_spec = opts.tty;
+    }
+
+    if (!mctpbridge.open(device_spec, baud, opts.hwflow,
+                opts.local_eid ? static_cast<uint8_t>(*opts.local_eid) : 0,{static_cast<uint8_t>(*opts.remote_eid)}, use_id_path_tag)) {
+        if (use_id_path_tag) {
+            std::cerr << "Failed to open serial bridge for ID_PATH_TAG '" << device_spec << "'\n";
+        } else {
+            std::cerr << "Failed to open serial bridge on " << device_spec << "\n";
+        }
         return EXIT_FAILURE;
     }
     // show the bridge configuration
     std::cout << "MCTP Bridge running:\n";
-    std::cout << "  TTY device: " << opts.tty << "\n";
+    if (use_id_path_tag) {
+        std::cout << "  ID_PATH_TAG: " << device_spec << "\n";
+    } else {
+        std::cout << "  TTY device: " << device_spec << "\n";
+    }
     std::cout << "  Baud rate: ";
     if (opts.baud) {
         std::cout << static_cast<int>(*(opts.baud)) << "\n";


### PR DESCRIPTION
This pull request introduces support for persistent USB serial device binding in the MCTP bridge by allowing users to specify a udev `ID_PATH_TAG` instead of a device node. This enables robust identification and recovery of USB serial ports, even when device names change or ports are reinserted. The implementation adds the `ManagedUsbTty` helper class, updates bridge logic to support this new binding mode, and documents usage for developers and users.

### Build system updates

* Modified CMake configuration to link against `libudev` unconditionally, ensuring that the new device discovery functionality is available. 

### Documentation and usage examples

* Updated `README.md` to explain the new persistent USB binding mode using `ID_PATH_TAG`, including how to determine the tag and example usage for both the bridge and Python helper script. 